### PR TITLE
chore: dde-launcher 6.0.11 integration

### DIFF
--- a/integration.yml
+++ b/integration.yml
@@ -6,12 +6,12 @@ milestone: V23-Beta
 # Required
 repos: 
   # Required
-  - repo: linuxdeepin/examplerepo
+  - repo: linuxdeepin/dde-launcher
     # Not required
-    tag: 5.11.22
+    tag: 6.0.11
     # Not required
     order: 0
     # Not required, but need one of tag and tagsha info
     # When use tag info, integration workflow will check repository tag and build tag version
     # When use tagsha info, interation workflow will build tagsha version, It doesn't matter whether the tag exists.
-    tagsha: "********************************"
+    tagsha: "3a3b191d76bc277a94dd56322ca92093f6951523"


### PR DESCRIPTION
集成 dde-launcher 6.0.11

本次修复的已知问题：

- https://github.com/linuxdeepin/developer-center/issues/4297

本次修复的其它问题：

- 在 debug 版 Qt 环境下，launcher 无法启动（由于设置了无效字重导致）
- 在较高分辨率的设备下，全屏图标在鼠标移动时加载卡顿问题（位图缓存过小导致重绘频繁）